### PR TITLE
Fix treatment of degenerate modes in linear molecules

### DIFF
--- a/pyvpt2/tests/test_hcn.py
+++ b/pyvpt2/tests/test_hcn.py
@@ -1,0 +1,34 @@
+import psi4
+import pytest
+
+import pyvpt2
+
+
+def test_hcn(driver):
+
+    mol = psi4.geometry("""
+    nocom
+    noreorient
+
+    H            0.000000000000     0.000000000000    -1.614875631638
+    C           -0.000000000000     0.000000000000    -0.548236744990
+    N            0.000000000000     0.000000000000     0.586039395549
+    """)
+
+    psi4.set_options({'d_convergence': 1e-10,
+                'e_convergence': 1e-10,
+                'points': 5})
+
+    options = {'METHOD': 'scf/cc-pvdz',
+            'FD': "HESSIAN",
+            'DISP_SIZE': 0.05}
+
+    ref_omega = [869.1587, 2421.4515, 3645.1338]
+    ref_anharmonic = [-19.8888, -23.6621, -125.1331]
+
+    results = pyvpt2.vpt2(mol, **options)
+    omega = results.omega[-3:]
+    anharmonic = results.nu[-3:] - omega
+
+    assert psi4.compare_values(ref_omega, omega, 0.1)
+    assert psi4.compare_values(ref_anharmonic, anharmonic, 0.1)

--- a/pyvpt2/tests/test_hcn.py
+++ b/pyvpt2/tests/test_hcn.py
@@ -4,8 +4,7 @@ import pytest
 import pyvpt2
 
 
-def test_hcn(driver):
-
+def test_hcn():
     mol = psi4.geometry("""
     nocom
     noreorient
@@ -24,11 +23,11 @@ def test_hcn(driver):
             'DISP_SIZE': 0.05}
 
     ref_omega = [869.1587, 2421.4515, 3645.1338]
-    ref_anharmonic = [-19.8888, -23.6621, -125.1331]
+    ref_anharmonic = [-19.8940, -23.6620, -125.1330]
 
     results = pyvpt2.vpt2(mol, **options)
     omega = results.omega[-3:]
     anharmonic = results.nu[-3:] - omega
 
-    assert psi4.compare_values(ref_omega, omega, 0.1)
-    assert psi4.compare_values(ref_anharmonic, anharmonic, 0.1)
+    assert psi4.compare_values(ref_omega, omega, 0.5)
+    assert psi4.compare_values(ref_anharmonic, anharmonic, 0.5)

--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -370,24 +370,43 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
     v_ind = harm["v_ind"]
     n_modes = harm["n_modes"]
 
+    degeneracy = np.ones(n_modes)
+    v_ind_nondegen = v_ind.copy() #
+    v_ind_degen = [] # degenerate modes
+    degen_mode_map = {}
+    # find degenerate modes:
+    for i,j in itertools.combinations(v_ind, 2):
+        if abs(omega[i] - omega[j]) < 0.2:
+            degeneracy[i] += 1
+            v_ind_degen.append(i)
+            v_ind_nondegen.remove(i)
+            v_ind_nondegen.remove(j)
+            # This assumes only linear mols (degeneracy of 2)
+            degen_mode_map[i] = j
+
+    v_ind_all = v_ind_nondegen.copy()
+    v_ind_all.extend(v_ind_degen)
     zeta, B = coriolis(mol, harm['q'])
     rotor_type = mol.rotor_type()
     fermi_list = identify_fermi(omega, phi_ijk, n_modes, v_ind, **kwargs)
 
     chi = np.zeros((n_modes, n_modes))
+    g = np.zeros((n_modes, n_modes))
     chi0 = 0.0
 
-    for i in v_ind:
+    # loop to solve non-degenerate anharmonicities
+    for i in v_ind_nondegen:
 
+        # TODO: Fix linear ZPVEs
         chi0 += phi_iijj[i, i]
         chi0 -= (7 / 9) * phi_ijk[i, i, i] ** 2 / omega[i]
 
-        for j in v_ind:
+        for j in v_ind_nondegen:
             if i == j:
                 chi[i, i] = phi_iijj[i, i]
 
-                for k in v_ind:
-                    if (k,(i,i)) in fermi_list:
+                for k in v_ind_nondegen:
+                    if (k, (i,i)) in fermi_list:
                         temp = (phi_ijk[i, i, k] ** 2 ) / 2
                         temp *= (1 / (2 * omega[i] + omega[k]) + 4 / omega[k])
                         chi[i,i] -= temp
@@ -407,7 +426,7 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
 
                 chi[i, j] += (4 * (omega[i] ** 2 + omega[j] ** 2) / (omega[i] * omega[j]) * rot)
 
-                for k in v_ind:
+                for k in v_ind_nondegen:
                     chi[i, j] -= (phi_ijk[i, i, k] * phi_ijk[j, j, k]) / omega[k]
 
                     if (k,(i,j)) in fermi_list:
@@ -464,6 +483,68 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
 
                 chi[i, j] /= 4
 
+        for j in v_ind_degen:
+            chi[i,j] = phi_iijj[i,j]
+
+            #TODO: handle multiple degeneracies
+            if (i,(j,j)) in fermi_list:
+                temp = 2 * omega[j] * phi_ijk[i,j,j]**2
+                temp *= 1 / (2*omega[j] + omega[i])
+                temp /= 4 * omega[j]
+                chi[i,j] -= temp
+
+            else:
+                temp = 2 * omega[j] * phi_ijk[i,j,j]**2
+                temp /= (4*omega[j]**2 - omega[i]**2)
+                chi[i,j] -= temp
+
+            for k in v_ind_nondegen:
+                chi[i,j] -= phi_ijk[i,i,k] * phi_ijk[j,j,k] / omega[k]
+
+            rot = 0
+            for b_ind in range(0, 3):
+                rot += B[b_ind] * (zeta[b_ind, i, j]) ** 2
+            chi[i, j] += 4 * rot * (omega[i] ** 2 + omega[j] ** 2) / (omega[i] * omega[j])
+            chi[i, j] /= 4
+            chi[j, i] = chi[i, j]
+
+    for i in v_ind_degen:
+        for j in v_ind_degen:
+            if i == j:
+                chi[i, i] = phi_iijj[i, i]
+                g[i, i] = -1/3 * phi_iijj[i, i]
+                g[i, i] += 7/3 * phi_ijk[i, i, i]**2 / omega[i]
+
+                for k in v_ind_nondegen:
+                    if (k,(i,i)) in fermi_list:
+                        temp = omega[k] * phi_ijk[k, i, i]**2
+                        temp *= 1 / (2*omega[i] + omega[k])
+                        temp /= 4 * omega[i]
+                        g[i, i] -= temp
+
+                    else:
+                        temp = omega[k] * phi_ijk[k, i, i]**2
+                        temp /= (4*omega[i]**2 - omega[k]**2)
+                        g[i, i] -= temp
+
+
+                for k in v_ind_all:
+                    if (k,(i,i)) in fermi_list:
+                        temp = (phi_ijk[i, i, k] ** 2 ) / 2
+                        temp *= (1 / (2 * omega[i] + omega[k]) + 4 / omega[k])
+                        chi[i,i] -= temp
+                    else:
+                        temp = ((8 * omega[i] ** 2 - 3 * omega[k] ** 2) * phi_ijk[i, i, k] ** 2)
+                        temp /= (omega[k] * (4 * omega[i] ** 2 - omega[k] ** 2))
+                        chi[i, i] -=  temp
+
+                chi[i,i] /= 16
+                g[i, i] /= 16
+
+            else:
+                # TODO: multiple degeneracies
+                pass
+
     for b_ind in range(3):
         if rotor_type == "RT_LINEAR": continue
         zeta_sum = 0
@@ -489,14 +570,19 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
     overtone = np.zeros(n_modes)
     band = np.zeros((n_modes, n_modes))
 
-    for i in v_ind:
-        anharmonic[i] = omega[i] + 2 * chi[i, i]
-        overtone[i] = 2*omega[i] + 6 * chi[i,i]
+    for i in v_ind_all:
 
-        for j in v_ind:
+        anharmonic[i] = omega[i] + (1 + degeneracy[i]) * chi[i, i] + g[i,i]
+        overtone[i] = 2*omega[i] + 2 * (2 + degeneracy[i]) * chi[i,i]
+
+        for j in v_ind_all:
             if j == i: continue
-            anharmonic[i] += 0.5 * chi[i, j]
-            overtone[i] += chi[i, j]
+            anharmonic[i] += 0.5 * chi[i, j] * degeneracy[j]
+            overtone[i] += chi[i, j] * degeneracy[j]
+
+        if i in v_ind_degen:
+            j = degen_mode_map[i]
+            anharmonic[j] = anharmonic[i]
 
     for [i, j] in itertools.combinations(v_ind, 2):
         band[i, j] = omega[i] + omega[j] + 2 * chi[i, i] + 2 * chi[j, j] + 2 * chi[i, j]


### PR DESCRIPTION
## Description
Fixes the treatment of degenerate modes in linear molecules.
Only affects results on linear molecules with Fermi resonant states.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add additional test on linear molecule HCN
  - [x] Fix treatment of degenerate modes in linear molecule
  - [x] Add option to omit low frequency modes below a specified threshold value

## Status
- [x] Ready to go

