### PR TITLE
Bugfix: only run degenerate vpt2 on linear molecules

### DIFF
--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -385,7 +385,7 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
     if check_rotor(mol) == "RT_LINEAR":
         # Only do degeneracies on linear mols for now
         for i,j in itertools.combinations(v_ind, 2):
-            if abs(omega[i] - omega[j]) < 0.2:
+            if abs(omega[i] - omega[j]) < 0.2: #TODO: tolerance value probably not ideal
                 degeneracy[i] += 1
                 v_ind_degen.append(i)
                 v_ind_nondegen.remove(i)

--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -382,14 +382,16 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
     v_ind_degen = [] # degenerate modes
     degen_mode_map = {}
     # find degenerate modes:
-    for i,j in itertools.combinations(v_ind, 2):
-        if abs(omega[i] - omega[j]) < 0.2:
-            degeneracy[i] += 1
-            v_ind_degen.append(i)
-            v_ind_nondegen.remove(i)
-            v_ind_nondegen.remove(j)
-            # This assumes only linear mols (degeneracy of 2)
-            degen_mode_map[i] = j
+    if check_rotor(mol) == "RT_LINEAR":
+        # Only do degeneracies on linear mols for now
+        for i,j in itertools.combinations(v_ind, 2):
+            if abs(omega[i] - omega[j]) < 0.2:
+                degeneracy[i] += 1
+                v_ind_degen.append(i)
+                v_ind_nondegen.remove(i)
+                v_ind_nondegen.remove(j)
+                # This assumes only linear mols (degeneracy of 2)
+                degen_mode_map[i] = j
 
     v_ind_all = v_ind_nondegen.copy()
     v_ind_all.extend(v_ind_degen)


### PR DESCRIPTION
## Description
Current implementation of degenerate VPT2 only valid for linear mols, so prevent it from running on anything else.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] only run degenerate VPT2 equations on linear molecules

## Status
- [x] Ready to go
