### PR TITLE
QCEngine Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ ENV/
 timer.dat
 psi*
 stdout*
+
+# vscode settings
+.vscode/

--- a/devtools/conda-envs/test_env_nightly.yaml
+++ b/devtools/conda-envs/test_env_nightly.yaml
@@ -10,11 +10,12 @@ dependencies:
   - qcfractal
   - qcportal
   - qcelemental
+  - nwchem
 
     # Base depends
   - python
   - pip
-  - pydantic
+  - pydantic < 2.0
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env_stable.yaml
+++ b/devtools/conda-envs/test_env_stable.yaml
@@ -8,6 +8,7 @@ dependencies:
   - qcfractal=0.50
   - qcportal
   - qcelemental
+  - nwchem
 
     # Base depends
   - python

--- a/pyvpt2/quartic.py
+++ b/pyvpt2/quartic.py
@@ -107,8 +107,8 @@ def _displace_cart(geom: np.ndarray, modes: np.ndarray, i_m: Iterator[Tuple], di
 
     Returns
     -------
-    np.ndarray
-        Displaced geometry
+    Tuple[np.ndarray, str]
+        Displaced geometry; label
     """
     label = []
     disp_geom = np.copy(geom)

--- a/pyvpt2/quartic.py
+++ b/pyvpt2/quartic.py
@@ -485,7 +485,7 @@ class QuarticComputer(BaseComputer):
 
         BaseComputer.__init__(self, **data)
 
-        data['keywords']['PARENT_SYMMETRY'] = self.molecule.point_group().full_name()
+        #data['keywords']['PARENT_SYMMETRY'] = self.molecule.point_group().full_name()
 
         self.method = data['method']
 
@@ -538,7 +538,7 @@ class QuarticComputer(BaseComputer):
 
             # If the user insists on symmetry, weaken it if some is lost when displacing.
             # or 'fix_symmetry' in self.findifrec.molecule
-            logger.debug(f'SYMM {clone.schoenflies_symbol()}')
+            #logger.debug(f'SYMM {clone.schoenflies_symbol()}')
             if self.molecule.symmetry_from_input():
                 disp_group = clone.find_highest_point_group()
                 new_bits = parent_group.bits() & disp_group.bits()

--- a/pyvpt2/quartic.py
+++ b/pyvpt2/quartic.py
@@ -191,7 +191,7 @@ def _geom_generator(mol: psi4.core.Molecule, data: Dict, mode: int) -> Dict:
                 append_geoms((index1, index2, index3), val)
 
     #  reference geometry only if we're doing multi-level calc
-    if data["options"].get("METHOD2", False):
+    if data["options"].get("MULTILEVEL", False):
         findifrec["reference"]["geometry"] = ref_geom
         findifrec["reference"]["do_reference"] = True
 

--- a/pyvpt2/quartic.py
+++ b/pyvpt2/quartic.py
@@ -533,6 +533,8 @@ class QuarticComputer(BaseComputer):
 
             # Load in displacement into the active molecule
             clone.set_geometry(psi4.core.Matrix.from_array(displacement["geometry"]))
+            #clone.update({"geometry": displacement["geometry"]})
+            #clone = Molecule(**clone)
 
             # If the user insists on symmetry, weaken it if some is lost when displacing.
             # or 'fix_symmetry' in self.findifrec.molecule

--- a/pyvpt2/result.py
+++ b/pyvpt2/result.py
@@ -4,10 +4,19 @@ try:
     from pydantic.v1 import Field
 except ImportError:
     from pydantic import Field
+
 from qcelemental.models import Molecule
 from qcelemental.models.basemodels import ProtoModel
 from qcelemental.models.common_models import Model
+from qcelemental.models.procedures import QCInputSpecification
 from qcelemental.models.types import Array
+
+
+class VPTInput(ProtoModel):
+    molecule: Molecule = Field(..., description="molecule")
+    keywords: Dict[str, Any] = Field({}, description="pyvpt2 kwargs")
+    input_specification: QCInputSpecification = Field(..., description="qc input")
+    #provenance
 
 
 class VPTResult(ProtoModel):

--- a/pyvpt2/result.py
+++ b/pyvpt2/result.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 try:
     from pydantic.v1 import Field
@@ -18,7 +18,7 @@ class VPTResult(ProtoModel):
     nu: Array[float] = Field(..., description="VPT2 Anharmonic vibrational frequencies")
     harmonic_zpve: Array[float] = Field(..., description="Harmonic zero-point vibrational energy")
     anharmonic_zpve : Array[float] = Field(..., description="VPT2 Anharmonic zero-point vibrational energy")
-    harmonic_intensity: Array[float] = Field(..., description="Harmonic IR intensities")
+    harmonic_intensity: Optional[Array[float]] = Field(..., description="Harmonic IR intensities")
     chi: Array[float] = Field(..., description="VPT2 anharmonicity constants")
     phi_ijk: Array[float] = Field(..., description="Cubic derivatives")
     phi_iijj: Array[float] = Field(..., description="Semi-diagonal quartic derivatives")

--- a/pyvpt2/schema.py
+++ b/pyvpt2/schema.py
@@ -1,22 +1,35 @@
 from typing import Any, Dict, Optional
 
 try:
-    from pydantic.v1 import Field
+    from pydantic.v1 import Field, conlist
 except ImportError:
-    from pydantic import Field
+    from pydantic import Field, conlist
 
 from qcelemental.models import Molecule
 from qcelemental.models.basemodels import ProtoModel
-from qcelemental.models.common_models import Model
+from qcelemental.models.common_models import Model, Provenance
 from qcelemental.models.procedures import QCInputSpecification
 from qcelemental.models.types import Array
 
+#from pyvpt2 import __version__
+
+
+def provenance_stamp() -> Dict[str, str]:
+    """
+    Return provenance stamp for pyvpt2
+    """
+    provenance = {
+        "creator": "pyVPT2",
+        "version": 0.0,
+        "routine": "VPT2"
+    }
+    return provenance
 
 class VPTInput(ProtoModel):
     molecule: Molecule = Field(..., description="molecule")
     keywords: Dict[str, Any] = Field({}, description="pyvpt2 kwargs")
-    input_specification: QCInputSpecification = Field(..., description="qc input")
-    #provenance
+    input_specification: conlist(item_type=QCInputSpecification, min_items=1, max_items=2) = Field(..., description="qc input")
+    #provenance: Provenance = Field(Provenance(**provenance_stamp()), description="provenance")
 
 
 class VPTResult(ProtoModel):
@@ -32,3 +45,4 @@ class VPTResult(ProtoModel):
     phi_ijk: Array[float] = Field(..., description="Cubic derivatives")
     phi_iijj: Array[float] = Field(..., description="Semi-diagonal quartic derivatives")
     extras: Dict[str, Any] = Field({}, description="Fun extras, e.g. depertubed freqs")
+    #provenance: Provenance = Field(..., description="provenance")

--- a/pyvpt2/schema.py
+++ b/pyvpt2/schema.py
@@ -26,10 +26,10 @@ def provenance_stamp() -> Dict[str, str]:
     return provenance
 
 class VPTInput(ProtoModel):
-    molecule: Molecule = Field(..., description="molecule")
-    keywords: Dict[str, Any] = Field({}, description="pyvpt2 kwargs")
-    input_specification: conlist(item_type=QCInputSpecification, min_items=1, max_items=2) = Field(..., description="qc input")
-    #provenance: Provenance = Field(Provenance(**provenance_stamp()), description="provenance")
+    molecule: Molecule = Field(..., description="Input molecule")
+    keywords: Dict[str, Any] = Field({}, description="pyVPT2 keywords")
+    input_specification: conlist(item_type=QCInputSpecification, min_items=1, max_items=2) = Field(..., description="QC input model")
+    provenance: Provenance = Field(Provenance(**provenance_stamp()), description="Provenance")
 
 
 class VPTResult(ProtoModel):
@@ -45,4 +45,4 @@ class VPTResult(ProtoModel):
     phi_ijk: Array[float] = Field(..., description="Cubic derivatives")
     phi_iijj: Array[float] = Field(..., description="Semi-diagonal quartic derivatives")
     extras: Dict[str, Any] = Field({}, description="Fun extras, e.g. depertubed freqs")
-    #provenance: Provenance = Field(..., description="provenance")
+    provenance: Provenance = Field(..., description="Provenance")

--- a/pyvpt2/schema.py
+++ b/pyvpt2/schema.py
@@ -44,5 +44,7 @@ class VPTResult(ProtoModel):
     chi: Array[float] = Field(..., description="VPT2 anharmonicity constants")
     phi_ijk: Array[float] = Field(..., description="Cubic derivatives")
     phi_iijj: Array[float] = Field(..., description="Semi-diagonal quartic derivatives")
+    rotational_constants: Array[float] = Field(..., description="Rotational constants")
+    zeta: Array[float] = Field(..., description="Coriolis coupling constants")
     extras: Dict[str, Any] = Field({}, description="Fun extras, e.g. depertubed freqs")
     provenance: Provenance = Field(..., description="Provenance")

--- a/pyvpt2/task_base.py
+++ b/pyvpt2/task_base.py
@@ -1,0 +1,281 @@
+#
+# @BEGIN LICENSE
+#
+# Psi4: an open-source quantum chemistry software package
+#
+# Copyright (c) 2007-2023 The Psi4 Developers.
+#
+# The copyrights for code used from other parties are included in
+# the corresponding files.
+#
+# This file is part of Psi4.
+#
+# Psi4 is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# Psi4 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with Psi4; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# @END LICENSE
+#
+
+__all__ = [
+    "AtomicComputer",
+    "BaseComputer",
+    "EnergyGradientHessianWfnReturn",
+]
+
+import abc
+import copy
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
+
+import qcelemental as qcel
+from qcelemental.models import AtomicInput, AtomicResult, DriverEnum
+
+qcel.models.molecule.GEOMETRY_NOISE = 13  # need more precision in geometries for high-res findif
+import qcengine as qcng
+from psi4 import core
+from psi4.driver import p4util
+
+if TYPE_CHECKING:
+    import qcportal
+
+logger = logging.getLogger(__name__)
+
+EnergyGradientHessianWfnReturn = Union[float, core.Matrix, Tuple[Union[float, core.Matrix], core.Wavefunction]]
+
+
+class BaseComputer(qcel.models.ProtoModel):
+    """Base class for "computers" that plan, run, and process QC tasks."""
+
+    @abc.abstractmethod
+    def compute(self):
+        pass
+
+    @abc.abstractmethod
+    def plan(self):
+        pass
+
+    class Config(qcel.models.ProtoModel.Config):
+        extra = "allow"
+        allow_mutation = True
+
+
+class AtomicComputer(BaseComputer):
+    """Computer for analytic single-geometry computations."""
+
+    molecule: Any = Field(..., description="The molecule to use in the computation.")
+    basis: str = Field(..., description="The quantum chemistry basis set to evaluate (e.g., 6-31g, cc-pVDZ, ...).")
+    method: str = Field(..., description="The quantum chemistry method to evaluate (e.g., B3LYP, MP2, ...).")
+    driver: DriverEnum = Field(..., description="The resulting type of computation: energy, gradient, hessian, properties."
+        "Note for finite difference that this should be the target driver, not the means driver.")
+    keywords: Dict[str, Any] = Field(default_factory=dict, description="The keywords to use in the computation.")
+    computed: bool = Field(False, description="Whether quantum chemistry has been run on this task.")
+    result: Any = Field(default_factory=dict, description=":py:class:`~qcelemental.models.AtomicResult` return.")
+    result_id: Optional[str] = Field(None, description="The optional ID for the computation.")
+    program: str = Field("psi4", description="The quantum chemistry program to run.")
+
+    class Config(qcel.models.ProtoModel.Config):
+        pass
+
+    @validator("basis")
+    def set_basis(cls, basis):
+        return basis.lower()
+
+    @validator("method")
+    def set_method(cls, method):
+        return method.lower()
+
+    @validator("keywords")
+    def set_keywords(cls, keywords):
+        return copy.deepcopy(keywords)
+
+    def plan(self) -> AtomicInput:
+        """Form QCSchema input from member data."""
+
+        atomic_model = AtomicInput(**{
+            "molecule": self.molecule.to_schema(dtype=2),
+            "driver": self.driver,
+            "model": {
+                "method": self.method,
+                "basis": self.basis
+            },
+            "keywords": self.keywords,
+            "protocols": {
+                "stdout": True,
+            },
+            "extras": {
+                "psiapi": True,
+                "wfn_qcvars_only": True,
+            },
+        })
+
+        return atomic_model
+
+    def compute(self, client: Optional["qcportal.client.FractalClient"] = None):
+        """Run quantum chemistry."""
+        from psi4.driver import pp
+
+        if self.computed:
+            return
+
+        if client:
+            self.computed = True
+
+            try:
+                # QCFractal v0.15.8
+                from qcportal.models import KeywordSet, Molecule
+                qca_next_branch = False
+            except ImportError:
+                # QCFractal `next`
+                from qcelemental.models import Molecule
+                qca_next_branch = True
+
+            # Build the molecule
+            mol = Molecule(**self.molecule.to_schema(dtype=2))
+
+            if not qca_next_branch:
+                # QCFractal v0.15.8
+
+                # Build the keywords
+                keyword_id = client.add_keywords([KeywordSet(values=self.keywords)])[0]
+
+                r = client.add_compute(self.program, self.method, self.basis, self.driver, keyword_id, [mol])
+                self.result_id = r.ids[0]
+                # NOTE: The following will re-run errored jobs by default
+                if self.result_id in r.existing:
+                    ret = client.query_tasks(base_result=self.result_id)
+                    if ret:
+                        if ret[0].status == "ERROR":
+                            client.modify_tasks("restart", base_result=self.result_id)
+                            logger.info("Resubmitting Errored Job {}".format(self.result_id))
+                        elif ret[0].status == "COMPLETE":
+                            logger.debug("Job already completed {}".format(self.result_id))
+                    else:
+                        logger.debug("Job already completed {}".format(self.result_id))
+                else:
+                    logger.debug("Submitting AtomicResult {}".format(self.result_id))
+
+            else:
+                # QCFractal `next`
+
+                meta, ids = client.add_singlepoints(
+                    molecules=mol,
+                    program=self.program,
+                    driver=self.driver,
+                    method=self.method,
+                    basis=self.basis,
+                    keywords=self.keywords,
+                    # protocols,
+                )
+                self.result_id = ids[0]
+                # NOTE: The following will re-run errored jobs by default
+                if meta.existing_idx:
+                    rec = client.get_singlepoints(self.result_id)
+                    if rec.status == "error":
+                        client.reset_records(self.result_id)
+                        logger.info("Resubmitting Errored Job {}".format(self.result_id))
+                    elif rec.status == "complete":
+                        logger.debug("Job already completed {}".format(self.result_id))
+                else:
+                    logger.debug("Submitting AtomicResult {}".format(self.result_id))
+
+            return
+
+        logger.info(f'<<< JSON launch ... {self.molecule.schoenflies_symbol()} {self.molecule.nuclear_repulsion_energy()}')
+        gof = core.get_output_file()
+
+        # EITHER ...
+        # from psi4.driver import schema_wrapper
+        # self.result = schema_wrapper.run_qcschema(self.plan())
+        # ... OR ...
+        self.result = qcng.compute(
+            self.plan(),
+            self.program,
+            raise_error=True,
+            # local_options below suitable for serial mode where each job takes all the resources of the parent Psi4 job.
+            #   distributed runs through QCFractal will likely need a different setup.
+            task_config={
+                # B -> GiB
+                "memory": core.get_memory() / (2 ** 30),
+                "ncores": core.get_num_threads(),
+            },
+        )
+        # ... END
+
+        #pp.pprint(self.result.dict())
+        #print("... JSON returns >>>")
+        core.set_output_file(gof, True)
+        core.reopen_outfile()
+        logger.debug(pp.pformat(self.result.dict()))
+        core.print_out(_drink_filter(self.result.dict()["stdout"]))
+        self.computed = True
+
+    def get_results(self, client: Optional["qcportal.FractalClient"] = None) -> AtomicResult:
+        """Return results as Atomic-flavored QCSchema."""
+
+        if self.result:
+            return self.result
+
+        if client:
+            try:
+                # QCFractal/QCPortal v0.15.8
+                result = client.query_results(id=self.result_id)
+                qca_next_branch = False
+            except AttributeError:
+                # QCFractal/QCPortal `next`
+                record = client.get_singlepoints(record_ids=self.result_id)
+                qca_next_branch = True
+
+            logger.debug(f"Querying AtomicResult {self.result_id}")
+
+            if not qca_next_branch:
+                # QCFractal v0.15.8
+                if len(result) == 0:
+                    return self.result
+
+                self.result = result[0]
+
+            else:
+                # QCFractal `next`
+                if record.status != "complete":
+                    return self.result
+
+                self.result = _singlepointrecord_to_atomicresult(record)
+
+            return self.result
+
+
+def _singlepointrecord_to_atomicresult(spr: "qcportal.singlepoint.SinglepointRecord") -> AtomicResult:
+    atres = spr.to_qcschema_result()
+
+    # QCFractal `next` database stores return_result, properties, and extras["qcvars"] merged
+    #   together and with lowercase keys. `to_qcschema_result` partitions properties back out,
+    #   but we need to restore qcvars keys, types, and dimensions.
+    qcvars = atres.extras.pop("extra_properties")
+    qcvars.pop("return_result")
+    qcvars = {k.upper(): p4util.plump_qcvar(k, v) for k, v in qcvars.items()}
+    atres.extras["qcvars"] = qcvars
+
+    return atres
+
+
+def _drink_filter(stdout: str) -> str:
+    """Don't mess up the widespread ``grep beer`` test of Psi4 doneness by printing multiple drinks per outfile."""
+
+    stdout = stdout.replace("\n*** Psi4 exiting successfully. Buy a developer a beer!", "")
+    stdout = stdout.replace("\n*** Psi4 encountered an error. Buy a developer more coffee!", "")
+    return stdout

--- a/pyvpt2/task_base.py
+++ b/pyvpt2/task_base.py
@@ -107,11 +107,8 @@ class AtomicComputer(BaseComputer):
         """Form QCSchema input from member data."""
 
         keywords = self.keywords
-        if keywords.get("function_kwargs", {}) is {}:
-            try:
+        if keywords.get("function_kwargs", {"dont pop if I dont exist :)"}) == {}:
                 keywords.pop("function_kwargs")
-            except:
-                pass
 
         atomic_model = AtomicInput(**{
             "molecule": self.molecule.to_schema(dtype=2),

--- a/pyvpt2/task_base.py
+++ b/pyvpt2/task_base.py
@@ -156,11 +156,17 @@ class AtomicComputer(BaseComputer):
             # Build the molecule
             mol = Molecule(**self.molecule.to_schema(dtype=2))
 
+            keywords = self.keywords
+            if keywords.get("function_kwargs", None) is not None:
+                keywords.pop("function_kwargs")
+            if keywords.get("PARENT_SYMMETRY", None) is not None:
+                keywords.pop("PARENT_SYMMETRY")
+
             if not qca_next_branch:
                 # QCFractal v0.15.8
 
                 # Build the keywords
-                keyword_id = client.add_keywords([KeywordSet(values=self.keywords)])[0]
+                keyword_id = client.add_keywords([KeywordSet(values=keywords)])[0]
 
                 r = client.add_compute(self.program, self.method, self.basis, self.driver, keyword_id, [mol])
                 self.result_id = r.ids[0]
@@ -187,7 +193,7 @@ class AtomicComputer(BaseComputer):
                     driver=self.driver,
                     method=self.method,
                     basis=self.basis,
-                    keywords=self.keywords,
+                    keywords=keywords,
                     # protocols,
                 )
                 self.result_id = ids[0]

--- a/pyvpt2/task_base.py
+++ b/pyvpt2/task_base.py
@@ -113,7 +113,7 @@ class AtomicComputer(BaseComputer):
                 "method": self.method,
                 "basis": self.basis
             },
-            "keywords": self.keywords,
+            "keywords": self.keywords.pop("function_kwargs"),
             "protocols": {
                 "stdout": True,
             },

--- a/pyvpt2/task_base.py
+++ b/pyvpt2/task_base.py
@@ -106,6 +106,13 @@ class AtomicComputer(BaseComputer):
     def plan(self) -> AtomicInput:
         """Form QCSchema input from member data."""
 
+        keywords = self.keywords
+        if keywords.get("function_kwargs", {}) is {}:
+            try:
+                keywords.pop("function_kwargs")
+            except:
+                pass
+
         atomic_model = AtomicInput(**{
             "molecule": self.molecule.to_schema(dtype=2),
             "driver": self.driver,
@@ -113,7 +120,7 @@ class AtomicComputer(BaseComputer):
                 "method": self.method,
                 "basis": self.basis
             },
-            "keywords": self.keywords.pop("function_kwargs"),
+            "keywords": keywords,
             "protocols": {
                 "stdout": True,
             },

--- a/pyvpt2/task_base.py
+++ b/pyvpt2/task_base.py
@@ -107,8 +107,13 @@ class AtomicComputer(BaseComputer):
         """Form QCSchema input from member data."""
 
         keywords = self.keywords
-        if keywords.get("function_kwargs", {"dont pop if I dont exist :)"}) == {}:
-                keywords.pop("function_kwargs")
+        if keywords.get("function_kwargs", None) is not None:
+            keywords.pop("function_kwargs")
+        if keywords.get("PARENT_SYMMETRY", None) is not None:
+            keywords.pop("PARENT_SYMMETRY")
+
+        if keywords.get("function_kwargs"):
+            print(keywords.get("function_kwargs"))
 
         atomic_model = AtomicInput(**{
             "molecule": self.molecule.to_schema(dtype=2),

--- a/pyvpt2/task_planner.py
+++ b/pyvpt2/task_planner.py
@@ -58,7 +58,7 @@ def hessian_planner(molecule: psi4.core.Molecule, qc_spec, **kwargs) -> QuarticC
         if program not in ["psi4"]:
             raise AssertionError("Composite methods enabled only for psi4 currently")
 
-        kwargs.update(cbsmeta)
+        findif_kwargs.update(cbsmeta)
 
         if driver == "hessian":
             logger.info('PLANNING CBS:  packet={packet} kw={findif_kwargs}')

--- a/pyvpt2/task_planner.py
+++ b/pyvpt2/task_planner.py
@@ -1,0 +1,136 @@
+import logging
+
+import psi4
+from psi4.driver.driver_cbs import CompositeComputer, composite_procedures
+from psi4.driver.driver_findif import FiniteDifferenceComputer
+from psi4.driver.task_planner import expand_cbs_methods
+
+from .quartic import QuarticComputer
+from .task_base import AtomicComputer, BaseComputer
+
+logger = logging.getLogger(f"psi4.{__name__}")
+
+def hessian_planner(method: str, molecule: psi4.core.Molecule, **kwargs) -> QuarticComputer:
+    """
+    Generates computer for finite difference calcutations
+
+    Parameters
+    ----------
+    method : str
+        Quantum chemistry method
+    molecule: psi4.core.Molecule
+        Input molecule
+
+    Returns
+    -------
+    QuarticComputer
+        Computer for finite difference calculations
+    """
+    # keywords are the psi4 option keywords
+
+    keywords = kwargs["QC_KWARGS"]
+    program = kwargs["QC_PROGRAM"]
+    if keywords == {} and program == "psi4":
+        keywords = psi4.p4util.prepare_options_for_set_options()
+    keywords.setdefault("function_kwargs", {})
+
+    der_dict = {"ENERGY": 0, "GRADIENT": 1, "HESSIAN": 2}
+    dermode = kwargs["FD"]
+    driver = "hessian"
+    dermode = [2, der_dict[dermode]]
+    method = method.lower()
+    basis = keywords.pop("BASIS", "(auto)")
+    findif_kwargs = {"findif_stencil_size": 5, "findif_step_size": 0.005, }
+
+    # Expand CBS methods
+    method, basis, cbsmeta = expand_cbs_methods(method=method, basis=basis, driver=driver)
+    if method in composite_procedures:
+        kwargs.update(cbsmeta)
+        kwargs.update({'cbs_metadata': composite_procedures[method](**kwargs)})
+        method = 'cbs'
+
+    packet = {"molecule": molecule, "driver": driver, "method": method, "basis": basis, "keywords": keywords, "program": program}
+
+    if method == "cbs":
+        if program not in ["psi4"]:
+            raise AssertionError("Composite methods enabled only for psi4 currently")
+
+        kwargs.update(cbsmeta)
+
+        if driver == "hessian":
+            logger.info('PLANNING CBS:  packet={packet} kw={kwargs}')
+            return CompositeComputer(**packet, **kwargs)
+
+        else:
+            logger.info(
+                f'PLANNING FD(CBS):  dermode={dermode} packet={packet} kw={kwargs}')
+            return FiniteDifferenceComputer(**packet,
+                                           findif_mode=dermode,
+                                           computer=CompositeComputer,
+                                           **findif_kwargs,
+                                           **kwargs)
+
+    else:
+        if driver == "hessian":
+            logger.info('PLANNING ATOMIC:  packet={packet} kw={kwargs}')
+            return AtomicComputer(**packet, **kwargs)
+
+        else:
+            logger.info(
+                f'PLANNING FD:  dermode={dermode} packet={packet} kw={kwargs}')
+            return FiniteDifferenceComputer(**packet,
+                                           findif_mode=dermode,
+                                           computer=AtomicComputer,
+                                           **findif_kwargs,
+                                           **kwargs)
+
+def quartic_planner(method: str, molecule: psi4.core.Molecule, **kwargs) -> QuarticComputer:
+    """
+    Generates computer for finite difference calcutations
+
+    Parameters
+    ----------
+    method : str
+        Quantum chemistry method
+    molecule: psi4.core.Molecule
+        Input molecule
+
+    Returns
+    -------
+    QuarticComputer
+        Computer for finite difference calculations
+    """
+    # keywords are the psi4 option keywords
+
+    keywords = kwargs["options"]["QC_KWARGS"]
+    program = kwargs["options"]["QC_PROGRAM"]
+    if keywords == {} and program == "psi4":
+        keywords = psi4.p4util.prepare_options_for_set_options()
+
+    driver = "hessian"
+    dermode = kwargs["options"]["FD"]
+    method = method.lower()
+    basis = keywords.pop("BASIS", "(auto)")
+
+    # Expand CBS methods
+    method, basis, cbsmeta = expand_cbs_methods(method=method, basis=basis, driver=driver)
+    if method in composite_procedures:
+        kwargs.update(cbsmeta)
+        kwargs.update({'cbs_metadata': composite_procedures[method](**kwargs)})
+        method = 'cbs'
+
+    packet = {"molecule": molecule, "driver": driver, "method": method, "basis": basis, "keywords": keywords, "program": program}
+
+    if method == "cbs":
+        if program not in ["psi4"]:
+            raise AssertionError("Composite methods enabled only for psi4 currently")
+
+        kwargs.update(cbsmeta)
+        logger.info(
+            f'PLANNING FD(CBS):  dermode={dermode} packet={packet} kw={kwargs}')
+        return QuarticComputer(**packet, computer=CompositeComputer, **kwargs)
+
+    else:
+        logger.info(
+            f'PLANNING FD:  dermode={dermode} keywords={keywords} kw={kwargs}')
+        return QuarticComputer(**packet, **kwargs)

--- a/pyvpt2/task_planner.py
+++ b/pyvpt2/task_planner.py
@@ -4,26 +4,28 @@ import psi4
 from psi4.driver.driver_cbs import CompositeComputer, composite_procedures
 from psi4.driver.driver_findif import FiniteDifferenceComputer
 from psi4.driver.task_planner import expand_cbs_methods
+from qcelemental.models import Molecule
+from qcelemental.models.procedures import QCInputSpecification
 
 from .quartic import QuarticComputer
 from .task_base import AtomicComputer, BaseComputer
 
 logger = logging.getLogger(f"psi4.{__name__}")
 
-def hessian_planner(molecule: psi4.core.Molecule, qc_spec, **kwargs) -> QuarticComputer:
+def hessian_planner(molecule: Molecule, qc_spec: QCInputSpecification, **kwargs) -> FiniteDifferenceComputer:
     """
-    Generates computer for finite difference calcutations
+    Generates computer for hessian finite difference calcutations
 
     Parameters
     ----------
-    method : str
-        Quantum chemistry method
-    molecule: psi4.core.Molecule
+    molecule: Molecule
         Input molecule
+    qc_spec: QCInputSpecification
+        Input specification
 
     Returns
     -------
-    QuarticComputer
+    FiniteDifference
         Computer for finite difference calculations
     """
     # keywords are the psi4 option keywords
@@ -85,16 +87,16 @@ def hessian_planner(molecule: psi4.core.Molecule, qc_spec, **kwargs) -> QuarticC
                                            computer=AtomicComputer,
                                            **findif_kwargs,)
 
-def quartic_planner(molecule: psi4.core.Molecule, qc_spec, **kwargs) -> QuarticComputer:
+def quartic_planner(molecule: Molecule, qc_spec: QCInputSpecification, **kwargs) -> QuarticComputer:
     """
-    Generates computer for finite difference calcutations
+    Generates computer for quartic finite difference calcutations
 
     Parameters
     ----------
-    method : str
-        Quantum chemistry method
-    molecule: psi4.core.Molecule
+    molecule: Molecule
         Input molecule
+    qc_spec: QCInputSpecification
+        Input specification
 
     Returns
     -------

--- a/pyvpt2/task_planner.py
+++ b/pyvpt2/task_planner.py
@@ -48,11 +48,11 @@ def hessian_planner(molecule: psi4.core.Molecule, qc_spec, **kwargs) -> QuarticC
     # Expand CBS methods
     method, basis, cbsmeta = expand_cbs_methods(method=method, basis=basis, driver=driver)
     if method in composite_procedures:
-        kwargs.update(cbsmeta)
-        kwargs.update({'cbs_metadata': composite_procedures[method](**kwargs)})
+        findif_kwargs.update(cbsmeta)
+        findif_kwargs.update({'cbs_metadata': composite_procedures[method](**kwargs)})
         method = 'cbs'
 
-    packet = {"molecule": molecule, "driver": driver, "method": method, "basis": basis, "keywords": keywords, "program": program}
+    packet = {"molecule": molecule, "driver": "hessian", "method": method, "basis": basis, "keywords": keywords, "program": program}
 
     if method == "cbs":
         if program not in ["psi4"]:
@@ -61,31 +61,29 @@ def hessian_planner(molecule: psi4.core.Molecule, qc_spec, **kwargs) -> QuarticC
         kwargs.update(cbsmeta)
 
         if driver == "hessian":
-            logger.info('PLANNING CBS:  packet={packet} kw={kwargs}')
-            return CompositeComputer(**packet, **kwargs)
+            logger.info('PLANNING CBS:  packet={packet} kw={findif_kwargs}')
+            return CompositeComputer(**packet, **findif_kwargs)
 
         else:
             logger.info(
-                f'PLANNING FD(CBS):  dermode={dermode} packet={packet} kw={kwargs}')
+                f'PLANNING FD(CBS):  dermode={dermode} packet={packet} kw={findif_kwargs}')
             return FiniteDifferenceComputer(**packet,
                                            findif_mode=dermode,
                                            computer=CompositeComputer,
-                                           **findif_kwargs,
-                                           **kwargs)
+                                           **findif_kwargs,)
 
     else:
         if driver == "hessian":
-            logger.info('PLANNING ATOMIC:  packet={packet} kw={kwargs}')
-            return AtomicComputer(**packet, **kwargs)
+            logger.info('PLANNING ATOMIC:  packet={packet} kw={findif_kwargs}')
+            return AtomicComputer(**packet, **findif_kwargs)
 
         else:
             logger.info(
-                f'PLANNING FD:  dermode={dermode} packet={packet} kw={kwargs}')
+                f'PLANNING FD:  dermode={dermode} packet={packet} kw={findif_kwargs}')
             return FiniteDifferenceComputer(**packet,
                                            findif_mode=dermode,
                                            computer=AtomicComputer,
-                                           **findif_kwargs,
-                                           **kwargs)
+                                           **findif_kwargs,)
 
 def quartic_planner(molecule: psi4.core.Molecule, qc_spec, **kwargs) -> QuarticComputer:
     """

--- a/pyvpt2/tests/test_h2co.py
+++ b/pyvpt2/tests/test_h2co.py
@@ -7,8 +7,6 @@ import pyvpt2
 def test_h2co_vpt2():
 
     mol = psi4.geometry("""
-    nocom
-    noreorient
     C
     O 1 R1
     H 1 R2 2 A1
@@ -22,14 +20,13 @@ def test_h2co_vpt2():
     R3 =    1.0915309601
     """)
 
-    psi4.set_options({'d_convergence': 1e-12,
+    qc_kwargs = {'d_convergence': 1e-12,
                 'e_convergence': 1e-12,
                 'scf_type': 'direct',
                 'puream': True,
-                'points': 5})
+                'points': 5}
 
-    options = {'METHOD': 'scf/6-31g*',
-            'FD': 'HESSIAN',
+    options = {'FD': 'HESSIAN',
             'DISP_SIZE': 0.05,
             'FERMI': True,
             'GVPT2': True}
@@ -40,7 +37,18 @@ def test_h2co_vpt2():
     ref_harm_zpve = 6408.5086
     ref_zpve_corr = -77.2184
 
-    results = pyvpt2.vpt2(mol, **options)
+    inp = {
+        "molecule": mol.to_schema(dtype=2),
+        "keywords": options,
+        "input_specification": [{
+            "model": {
+                "method": "scf",
+                "basis": "6-31g*"
+            },
+            "keywords": qc_kwargs}]
+        }
+
+    results = pyvpt2.vpt2_from_schema(inp)
     omega = results.omega[-6:]
     anharmonic = results.nu[-6:] - omega
     harm_zpve  = results.harmonic_zpve

--- a/pyvpt2/tests/test_h2o.py
+++ b/pyvpt2/tests/test_h2o.py
@@ -8,9 +8,6 @@ import pyvpt2
 def test_h2o_vpt2(driver):
 
     mol = psi4.geometry("""
-    nocom
-    noreorient
-
     O
     H 1 R1
     H 1 R2 2 A
@@ -18,32 +15,36 @@ def test_h2o_vpt2(driver):
     R1    =        0.94731025924472878064
     R2    =        0.94731025924472878064
     A    =      105.5028950965639
-
-    symmetry c2v
     """)
 
-    psi4.set_options({'d_convergence': 1e-12,
+    qc_kwargs = {'d_convergence': 1e-12,
                 'e_convergence': 1e-12,
                 'scf_type': 'direct',
                 'puream': True,
-                'points': 5})
+                'points': 5}
 
-    options = {'METHOD': 'scf/6-31g*',
-            'FD': driver,
+    options = {'FD': driver,
             'DISP_SIZE': 0.05}
 
-    cfour_omega = [1826.8154, 4060.2203, 4177.8273]
-    cfour_anharmonic = [-54.0635, -158.2345, -177.9707]
-    cfour_harm_zpve = 5032.431
-    cfour_zpve_corr = -70.352
+    ref_omega = [1826.8154, 4060.2203, 4177.8273]
+    ref_anharmonic = [-54.0635, -158.2345, -177.9707]
+    ref_harm_zpve = 5032.431
+    ref_zpve_corr = -70.352
 
-    results = pyvpt2.vpt2(mol, **options)
+    inp = {"molecule": mol.to_schema(dtype=2),
+           "input_specification": [{"model":{
+                                        "method": "scf",
+                                        "basis": "6-31g*"},
+                                   "keywords": qc_kwargs}],
+           "keywords": options}
+
+    results = pyvpt2.vpt2_from_schema(inp)
     omega = results.omega[-3:]
     anharmonic = results.nu[-3:] - omega
     harm_zpve  = results.harmonic_zpve
     zpve_corr = results.anharmonic_zpve - harm_zpve
 
-    assert psi4.compare_values(cfour_omega, omega, 0.1)
-    assert psi4.compare_values(cfour_anharmonic, anharmonic, 0.1)
-    assert psi4.compare_values(cfour_harm_zpve, harm_zpve, 0.1)
-    assert psi4.compare_values(cfour_zpve_corr, zpve_corr, 0.1)
+    assert psi4.compare_values(ref_omega, omega, 0.1)
+    assert psi4.compare_values(ref_anharmonic, anharmonic, 0.1)
+    assert psi4.compare_values(ref_harm_zpve, harm_zpve, 0.1)
+    assert psi4.compare_values(ref_zpve_corr, zpve_corr, 0.1)

--- a/pyvpt2/tests/test_h2o_cbs.py
+++ b/pyvpt2/tests/test_h2o_cbs.py
@@ -8,9 +8,6 @@ import pyvpt2
 def test_h2o_cbs_vpt2(driver):
 
     mol = psi4.geometry("""
-    nocom
-    noreorient
-
     O
     H 1 R1
     H 1 R2 2 A
@@ -18,24 +15,30 @@ def test_h2o_cbs_vpt2(driver):
     A         =  106.3819454243
     R1        =    0.9392155213
     R2        =    0.9392155213
-
-    symmetry c2v
     """)
 
-    psi4.set_options({'d_convergence': 1e-12,
-                'e_convergence': 1e-12,
-                'points': 5})
+    qc_kwargs = {'d_convergence': 1e-12,
+                'e_convergence': 1e-12}
 
-    options = {'METHOD': 'scf/cc-pv[dt]z',
-            'FD': driver,
+    options = {'FD': driver,
             'DISP_SIZE': 0.05}
+
+    inp = {
+        "molecule": mol.to_schema(dtype=2),
+        "keywords": options,
+        "input_specification": [{
+            "model": {
+                "method": "scf/cc-pv[dt]z",
+                "basis": "(auto)"},
+            "keywords": qc_kwargs}]
+        }
 
     ref_omega = [1747.4491, 4129.8877, 4230.4755]
     ref_anharmonic = [-53.8382, -157.1904, -171.4518]
     ref_harm_zpve = 5053.9062
     ref_zpve_corr = -69.5146
 
-    results = pyvpt2.vpt2(mol, **options)
+    results = pyvpt2.vpt2_from_schema(inp)
     omega = results.omega[-3:]
     anharmonic = results.nu[-3:] - omega
     harm_zpve  = results.harmonic_zpve

--- a/pyvpt2/tests/test_h2o_cfour.py
+++ b/pyvpt2/tests/test_h2o_cfour.py
@@ -4,16 +4,22 @@ import qcengine as qcng
 
 import pyvpt2
 
-no_cfour = 'cfour' not in qcng.list_available_programs()
 
-@pytest.mark.skipif(no_cfour, reason="CFOUR not installed")
 @pytest.mark.parametrize("driver", ["ENERGY", "GRADIENT", "HESSIAN"])
-def test_h2o_vpt2(driver):
+@pytest.mark.parametrize("program", ["psi4", "cfour", "nwchem"])
+def test_h2o_vpt2(driver, program):
+
+    if program not in qcng.list_available_programs():
+        pytest.skip()
+
+    qc_kwargs = {"psi4": {"e_convergence": 12,
+                          "puream": True},
+                 "cfour": {"SCF_CONV": 12},
+                 "nwchem": {"scf": "",
+                            "   thresh": 8,
+                            "end": "",}}
 
     mol = psi4.geometry("""
-    nocom
-    noreorient
-
     O
     H 1 R1
     H 1 R2 2 A
@@ -21,28 +27,33 @@ def test_h2o_vpt2(driver):
     R1    =        0.94731025924472878064
     R2    =        0.94731025924472878064
     A    =      105.5028950965639
-
-    symmetry c2v
     """)
 
     options = {'METHOD': 'scf/6-31G*',
             'FD': driver,
             'DISP_SIZE': 0.05,
-            'QC_PROGRAM': 'cfour',
-            'QC_KWARGS': {'SCF_CONV': 12}}
+            'QC_PROGRAM': program}
 
-    cfour_omega = [1826.8154, 4060.2203, 4177.8273]
-    cfour_anharmonic = [-54.0635, -158.2345, -177.9707]
-    cfour_harm_zpve = 5032.431
-    cfour_zpve_corr = -70.352
+    ref_omega = [1826.8154, 4060.2203, 4177.8273]
+    ref_anharmonic = [-54.0635, -158.2345, -177.9707]
+    ref_harm_zpve = 5032.431
+    ref_zpve_corr = -70.352
 
-    results = pyvpt2.vpt2(mol, **options)
+    inp = {"molecule": mol.to_schema(dtype=2),
+           "input_specification":[{
+               "model": {"method": "scf",
+                         "basis": "6-31g*"},
+                "keywords": qc_kwargs[program]
+           }],
+           "keywords": options}
+
+    results = pyvpt2.vpt2_from_schema(inp)
     omega = results.omega[-3:]
     anharmonic = results.nu[-3:] - omega
     harm_zpve  = results.harmonic_zpve
     zpve_corr = results.anharmonic_zpve - harm_zpve
 
-    assert psi4.compare_values(cfour_omega, omega, 0.2), "omega"
-    assert psi4.compare_values(cfour_anharmonic, anharmonic, 0.2), "anharmonic correction"
-    assert psi4.compare_values(cfour_harm_zpve, harm_zpve, 0.2), "harmonic ZPVE"
-    assert psi4.compare_values(cfour_zpve_corr, zpve_corr, 0.2), "ZPVE correction"
+    assert psi4.compare_values(ref_omega, omega, 0.2), "omega"
+    assert psi4.compare_values(ref_anharmonic, anharmonic, 0.2), "anharmonic correction"
+    assert psi4.compare_values(ref_harm_zpve, harm_zpve, 0.2), "harmonic ZPVE"
+    assert psi4.compare_values(ref_zpve_corr, zpve_corr, 0.2), "ZPVE correction"

--- a/pyvpt2/tests/test_h2o_cfour.py
+++ b/pyvpt2/tests/test_h2o_cfour.py
@@ -29,8 +29,7 @@ def test_h2o_vpt2(driver, program):
     A    =      105.5028950965639
     """)
 
-    options = {'METHOD': 'scf/6-31G*',
-            'FD': driver,
+    options = {'FD': driver,
             'DISP_SIZE': 0.05,
             'QC_PROGRAM': program}
 

--- a/pyvpt2/tests/test_h2o_cfour.py
+++ b/pyvpt2/tests/test_h2o_cfour.py
@@ -1,0 +1,48 @@
+import psi4
+import pytest
+import qcengine as qcng
+
+import pyvpt2
+
+no_cfour = 'cfour' not in qcng.list_available_programs()
+
+@pytest.mark.skipif(no_cfour, reason="CFOUR not installed")
+@pytest.mark.parametrize("driver", ["ENERGY", "GRADIENT", "HESSIAN"])
+def test_h2o_vpt2(driver):
+
+    mol = psi4.geometry("""
+    nocom
+    noreorient
+
+    O
+    H 1 R1
+    H 1 R2 2 A
+
+    R1    =        0.94731025924472878064
+    R2    =        0.94731025924472878064
+    A    =      105.5028950965639
+
+    symmetry c2v
+    """)
+
+    options = {'METHOD': 'scf/6-31G*',
+            'FD': driver,
+            'DISP_SIZE': 0.05,
+            'QC_PROGRAM': 'cfour',
+            'QC_KWARGS': {'SCF_CONV': 12}}
+
+    cfour_omega = [1826.8154, 4060.2203, 4177.8273]
+    cfour_anharmonic = [-54.0635, -158.2345, -177.9707]
+    cfour_harm_zpve = 5032.431
+    cfour_zpve_corr = -70.352
+
+    results = pyvpt2.vpt2(mol, **options)
+    omega = results.omega[-3:]
+    anharmonic = results.nu[-3:] - omega
+    harm_zpve  = results.harmonic_zpve
+    zpve_corr = results.anharmonic_zpve - harm_zpve
+
+    assert psi4.compare_values(cfour_omega, omega, 0.2), "omega"
+    assert psi4.compare_values(cfour_anharmonic, anharmonic, 0.2), "anharmonic correction"
+    assert psi4.compare_values(cfour_harm_zpve, harm_zpve, 0.2), "harmonic ZPVE"
+    assert psi4.compare_values(cfour_zpve_corr, zpve_corr, 0.2), "ZPVE correction"

--- a/pyvpt2/tests/test_h2o_cfour.py
+++ b/pyvpt2/tests/test_h2o_cfour.py
@@ -13,7 +13,8 @@ def test_h2o_vpt2(driver, program):
         pytest.skip()
 
     qc_kwargs = {"psi4": {"e_convergence": 12,
-                          "puream": True},
+                          "puream": True,
+                          "scf_type": "direct"},
                  "cfour": {"SCF_CONV": 12},
                  "nwchem": {"scf": "",
                             "   thresh": 8,

--- a/pyvpt2/tests/test_h2o_multilevel.py
+++ b/pyvpt2/tests/test_h2o_multilevel.py
@@ -8,9 +8,6 @@ import pyvpt2
 def test_h2o_multi_vpt2(driver):
 
     mol = psi4.geometry("""
-    nocom
-    noreorient
-
     O
     H 1 R1
     H 1 R2 2 A
@@ -18,17 +15,12 @@ def test_h2o_multi_vpt2(driver):
     R1    =        0.9406103293
     R2    =        0.9406103293
     A    =      106.0259742413
-
-    symmetry c2v
     """)
 
-    psi4.set_options({'d_convergence': 1e-12,
-                'e_convergence': 1e-12,
-                'points': 5})
+    qc_kwargs = {'d_convergence': 1e-12,
+                'e_convergence': 1e-12,}
 
-    options = {'METHOD': 'scf/cc-pvtz',
-            'METHOD2': 'scf/cc-pvdz',
-            'FD': driver,
+    options = {'FD': driver,
             'DISP_SIZE': 0.05}
 
     ref_omega = [1752.8008, 4126.8616, 4226.9977]
@@ -36,7 +28,19 @@ def test_h2o_multi_vpt2(driver):
     ref_harm_zpve = 5053.3300
     ref_zpve_corr = -79.2130
 
-    results = pyvpt2.vpt2(mol, **options)
+    inp = {"molecule": mol.to_schema(dtype=2),
+           "input_specification": [{"model":{
+                                        "method": "scf",
+                                        "basis": "cc-pvtz"},
+                                   "keywords": qc_kwargs},
+                                   {"model":{
+                                       "method": "scf",
+                                       "basis": "cc-pvdz"},
+                                   "keywords": qc_kwargs}
+                                   ],
+           "keywords": options}
+
+    results = pyvpt2.vpt2_from_schema(inp)
     omega = results.omega[-3:]
     anharmonic = results.nu[-3:] - omega
     harm_zpve  = results.harmonic_zpve

--- a/pyvpt2/tests/test_h2o_qcng.py
+++ b/pyvpt2/tests/test_h2o_qcng.py
@@ -7,18 +7,23 @@ import pyvpt2
 
 @pytest.mark.parametrize("driver", ["ENERGY", "GRADIENT", "HESSIAN"])
 @pytest.mark.parametrize("program", ["psi4", "cfour", "nwchem"])
-def test_h2o_vpt2(driver, program):
+def test_h2o_vpt2_qcng(driver, program):
 
     if program not in qcng.list_available_programs():
         pytest.skip()
+
+    if program == "nwchem" and driver == "ENERGY":
+        pytest.skip()
+        #TODO: resolve likely precision issue with nwchem energy findif
 
     qc_kwargs = {"psi4": {"e_convergence": 12,
                           "puream": True,
                           "scf_type": "direct"},
                  "cfour": {"SCF_CONV": 12},
-                 "nwchem": {"scf": "",
-                            "   thresh": 8,
-                            "end": "",}}
+                 "nwchem": {"scf__thresh": 1e-10,
+                            "basis__spherical": True,
+                            "geometry__autosym": 0.000001,
+                            }}
 
     mol = psi4.geometry("""
     O

--- a/pyvpt2/tests/test_h2o_snowflake2.py
+++ b/pyvpt2/tests/test_h2o_snowflake2.py
@@ -25,8 +25,8 @@ def test_h2o_snowflake_vpt2(driver, program):
                           "puream": True,
                           "scf_type": "direct"},
                  "cfour": {"SCF_CONV": 12},
-                 "nwchem": {"scf__thresh": 8,
-                            "basis__spherical": "",
+                 "nwchem": {"scf__thresh": 1e-8,
+                            "basis__spherical": True,
                             }}
 
     mol = psi4.geometry("""

--- a/pyvpt2/tests/test_h2o_snowflake2.py
+++ b/pyvpt2/tests/test_h2o_snowflake2.py
@@ -1,0 +1,85 @@
+import psi4
+import pytest
+import qcengine as qcng
+
+import pyvpt2
+
+no_qcfractal = False
+try:
+    from qcfractal.snowflake import FractalSnowflake
+except:
+    no_qcfractal = True
+
+@pytest.mark.skipif(no_qcfractal, reason="QCFractal not installed")
+@pytest.mark.parametrize("driver", ["HESSIAN"])
+@pytest.mark.parametrize("program", ["psi4", "cfour", "nwchem"])
+def test_h2o_snowflake_vpt2(driver, program):
+
+    if program not in qcng.list_available_programs():
+        pytest.skip()
+
+    snowflake = FractalSnowflake()
+    client = snowflake.client()
+
+    qc_kwargs = {"psi4": {"e_convergence": 12,
+                          "puream": True,
+                          "scf_type": "direct"},
+                 "cfour": {"SCF_CONV": 12},
+                 "nwchem": {"scf__thresh": 8,
+                            "basis__spherical": "",
+                            }}
+
+    mol = psi4.geometry("""
+    O
+    H 1 R1
+    H 1 R2 2 A
+
+    R1    =        0.94731025924472878064
+    R2    =        0.94731025924472878064
+    A    =      105.5028950965639
+    """)
+
+    options = {'FD': driver,
+            'DISP_SIZE': 0.05,
+            'RETURN_PLAN': True,
+            'QC_PROGRAM': program}
+
+    ref_omega = [1826.8154, 4060.2203, 4177.8273]
+    ref_anharmonic = [-54.0635, -158.2345, -177.9707]
+    ref_harm_zpve = 5032.431
+    ref_zpve_corr = -70.352
+
+    inp = {
+        "molecule": mol.to_schema(dtype=2),
+        "keywords": options,
+        "input_specification": [{
+            "model": {
+                "method": "scf",
+                "basis": "6-31g*"},
+            "keywords": qc_kwargs[program]
+        }]
+    }
+
+    harmonic_plan = pyvpt2.vpt2_from_schema(inp)
+    harmonic_plan.compute(client=client)
+    snowflake.await_results()
+    harmonic_ret = harmonic_plan.get_results(client=client)
+    print(harmonic_ret)
+
+    plan = pyvpt2.vpt2_from_harmonic(harmonic_ret, qc_spec=inp["input_specification"][0], **options)
+    plan.compute(client=client)
+    snowflake.await_results()
+    ret = plan.get_results(client=client)
+    results = pyvpt2.process_vpt2(ret, **options)
+
+    omega = results.omega[-3:]
+    anharmonic = results.nu[-3:] - omega
+    harm_zpve  = results.harmonic_zpve
+    zpve_corr = results.anharmonic_zpve - harm_zpve
+
+    assert psi4.compare_values(ref_omega, omega, 0.5)
+    assert psi4.compare_values(ref_anharmonic, anharmonic, 0.5)
+    assert psi4.compare_values(ref_harm_zpve, harm_zpve, 0.5)
+    assert psi4.compare_values(ref_zpve_corr, zpve_corr, 0.5)
+
+    snowflake.stop()

--- a/pyvpt2/tests/test_hcn.py
+++ b/pyvpt2/tests/test_hcn.py
@@ -6,26 +6,29 @@ import pyvpt2
 
 def test_hcn():
     mol = psi4.geometry("""
-    nocom
-    noreorient
-
     H            0.000000000000     0.000000000000    -1.614875631638
     C           -0.000000000000     0.000000000000    -0.548236744990
     N            0.000000000000     0.000000000000     0.586039395549
     """)
 
-    psi4.set_options({'d_convergence': 1e-10,
+    qc_kwargs = {'d_convergence': 1e-10,
                 'e_convergence': 1e-10,
-                'points': 5})
+                'points': 5}
 
-    options = {'METHOD': 'scf/cc-pvdz',
-            'FD': "HESSIAN",
-            'DISP_SIZE': 0.05}
+    options = {'FD': "HESSIAN",
+        'DISP_SIZE': 0.05}
 
     ref_omega = [869.1587, 2421.4515, 3645.1338]
     ref_anharmonic = [-19.8940, -23.6620, -125.1330]
 
-    results = pyvpt2.vpt2(mol, **options)
+    inp = {"molecule": mol.to_schema(dtype=2),
+           "input_specification": [{"model":{
+                                        "method": "scf",
+                                        "basis": "cc-pvdz"},
+                                   "keywords": qc_kwargs}],
+           "keywords": options}
+
+    results = pyvpt2.vpt2_from_schema(inp)
     omega = results.omega[-3:]
     anharmonic = results.nu[-3:] - omega
 

--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -183,8 +183,6 @@ def process_options_keywords(**kwargs) -> Dict:
 
     keyword_defaults = {
         "DISP_SIZE": 0.05,
-        "METHOD": "SCF",
-        "METHOD_2": None,
         "FD": "HESSIAN",
         "FERMI": True,
         "GVPT2": False,
@@ -193,6 +191,7 @@ def process_options_keywords(**kwargs) -> Dict:
         "RETURN_PLAN": False,
         "VPT2_OMEGA_THRESH": 1,
         "QC_PROGRAM": "psi4",
+        "MULTILEVEL": False,
     }
 
     for k in kwargs.keys():
@@ -283,6 +282,7 @@ def vpt2_from_schema(inp: VPTInput) -> VPTResult:
         qc_specification2 = inp.input_specification[0]
     else:
         qc_specification2 = inp.input_specification[1]
+        kwargs.update({"MULTILEVEL": True})
 
     mol = mol.orient_molecule()
     mol = mol.dict()

--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -9,6 +9,7 @@ import psi4
 from psi4.driver.driver_cbs import CompositeComputer
 from psi4.driver.driver_findif import FiniteDifferenceComputer
 from qcelemental.models import AtomicResult
+from qcelemental.models.procedures import QCInputSpecification
 
 #Local imports:
 from . import quartic
@@ -361,6 +362,13 @@ def vpt2_from_harmonic(harmonic_result: AtomicResult, qc_spec, **kwargs) -> quar
     QuarticComputer
         Computer for quartic finite difference calculation
     """
+    if isinstance(qc_spec, dict):
+        qc_spec = QCInputSpecification(**qc_spec)
+    elif isinstance(qc_spec, QCInputSpecification):
+        qc_spec = qc_spec.copy()
+    else:
+        raise AssertionError("Input type not recognized.")
+
     kwargs = process_options_keywords(**kwargs)
     wfn = _findif_schema_to_wfn(harmonic_result)
     harm = process_harmonic(wfn, **kwargs)

--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -706,7 +706,7 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
         chi = chi,
         phi_ijk = phi_ijk,
         phi_iijj = phi_iijj,
-        rotational_constant = B,
+        rotational_constants = B,
         zeta = zeta,
         extras = extras,
         provenance = provenance_stamp()

--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -21,24 +21,6 @@ from .task_planner import hessian_planner, quartic_planner
 logger = logging.getLogger(f"psi4.{__name__}")
 
 TaskComputers = Union[AtomicComputer, CompositeComputer, FiniteDifferenceComputer]
-def harmonic(mol: psi4.core.Molecule, **kwargs) -> TaskComputers:
-    """
-    Generates plan for harmonic reference calculation
-
-    Parameters
-    ----------
-    mol : psi4.core.Molecule
-        Input molecule
-
-    Returns
-    -------
-    TaskComputers
-        Computer for reference harmonic calculation
-    """
-
-    method = kwargs["METHOD"]
-    plan = hessian_planner(method=method, molecule=mol, **kwargs)
-    return plan
 
 def _findif_schema_to_wfn(findif_model: AtomicResult) -> psi4.core.Wavefunction:
     """Helper function to produce Wavefunction and Psi4 files from a FiniteDifference-flavored AtomicResult."""

--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -14,7 +14,7 @@ from qcelemental.models import AtomicResult
 from . import quartic
 from .constants import *
 from .fermi_solver import Interaction, State, fermi_solver
-from .schema import VPTInput, VPTResult
+from .schema import VPTInput, VPTResult, provenance_stamp
 from .task_base import AtomicComputer
 from .task_planner import hessian_planner, quartic_planner
 
@@ -698,7 +698,8 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
         chi = chi,
         phi_ijk = phi_ijk,
         phi_iijj = phi_iijj,
-        extras = extras
+        extras = extras,
+        provenance = provenance_stamp()
         )
 
     v_ind_print = harm["v_ind_omitted"]

--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -265,6 +265,19 @@ def check_rotor(mol: psi4.core.Molecule):
     return rotor_type
 
 def vpt2_from_schema(inp: VPTInput) -> VPTResult:
+    """
+    Performs vibrational pertubration theory calculation
+
+    Parameters
+    ----------
+    inp: VPInput
+        Input schema
+
+    Returns
+    -------
+    VPTResult
+        VPT2 results schema
+    """
 
     from qcelemental.models.molecule import Molecule
 
@@ -310,7 +323,8 @@ def vpt2_from_schema(inp: VPTInput) -> VPTResult:
 
 def vpt2(mol: psi4.core.Molecule, **kwargs) -> Dict:
     """
-    Performs vibrational pertubration theory calculation
+    Performs vibrational pertubration theory calculation)
+    (Deprecated)
 
     Parameters
     ----------
@@ -433,7 +447,7 @@ def identify_fermi(omega: np.ndarray, phi_ijk: np.ndarray, n_modes: np.ndarray, 
 
     return fermi_list
 
-def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
+def process_vpt2(quartic_result: AtomicResult, **kwargs) -> VPTResult:
     """
     Calculate VPT2 results from quartic forces
 
@@ -444,8 +458,8 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
 
     Returns
     -------
-    Dict
-        Results dictionary for VPT2 caclutation
+    VPTResult
+        Results schema for VPT2 caclutation
     """
     kwargs = process_options_keywords(**kwargs)
     mol = psi4.core.Molecule.from_schema(quartic_result.molecule.dict())
@@ -692,7 +706,7 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> Dict:
     if kwargs["FERMI"] and kwargs["GVPT2"]:
         deperturbed = anharmonic.copy()
         extras.update({"Deperturbed Freq": deperturbed})
-        fermi_nu, fermi_ind = process_fermi_solver(fermi_list, v_ind, anharmonic, overtone, band, phi_ijk)
+        fermi_nu, fermi_ind = process_fermi_solver(fermi_list, v_ind, anharmonic, overtone, band, phi_ijk) #this works in-place
 
     ret = VPTResult(
         molecule = quartic_result.molecule,
@@ -779,8 +793,8 @@ def print_result(results: VPTResult, v_ind: np.ndarray):
 
     Parameters
     ----------
-    results : VPT2
-        Dataclass of VPT2 results
+    results : VPTResult
+        Schema of VPT2 results
     v_ind : np.ndarray
         List of vibrational indices
     """


### PR DESCRIPTION
## Description
Refactor to allow computation through qcengine rather than psi4

## Todos
  - [x] allow program specification in `AtomicComputer` class so that any qc program can run end-point computations
  - [x] allow schema-fied inputs
  - [x] fix multi-level inputs
  - [x] rewrite test inputs
  - [x] test other programs through qcfractal
  - [x] test other programs through CI
  - [x] fix type-hints and docstrings


## Status
- [x] Ready to go
