### PR TITLE
Local task config pass through

### DIFF
--- a/pyvpt2/quartic.py
+++ b/pyvpt2/quartic.py
@@ -519,6 +519,7 @@ class QuarticComputer(BaseComputer):
                 "basis": data["basis"],
                 "keywords": data["keywords"] or {},
                 "program": data["program"],
+                "task_config": data["options"]["TASK_CONFIG"],
             }
             if 'cbs_metadata' in data:
                 packet['cbs_metadata'] = data['cbs_metadata']
@@ -552,6 +553,7 @@ class QuarticComputer(BaseComputer):
                 "basis": data["basis"],
                 "keywords": data["keywords"] or {},
                 "program": data["program"],
+                "task_config": data["options"]["TASK_CONFIG"],
             }
             if 'cbs_metadata' in data:
                 packet['cbs_metadata'] = data['cbs_metadata']

--- a/pyvpt2/task_base.py
+++ b/pyvpt2/task_base.py
@@ -87,6 +87,7 @@ class AtomicComputer(BaseComputer):
     result: Any = Field(default_factory=dict, description=":py:class:`~qcelemental.models.AtomicResult` return.")
     result_id: Optional[str] = Field(None, description="The optional ID for the computation.")
     program: str = Field("psi4", description="The quantum chemistry program to run.")
+    task_config: Dict[str, Any] = Field(default_factory=dict, description="Task config for jobs.")
 
     class Config(qcel.models.ProtoModel.Config):
         pass
@@ -221,14 +222,8 @@ class AtomicComputer(BaseComputer):
             self.plan(),
             self.program,
             raise_error=True,
-            # local_options below suitable for serial mode where each job takes all the resources of the parent Psi4 job.
-            #   distributed runs through QCFractal will likely need a different setup.
-            task_config={
-                # B -> GiB
-                "memory": core.get_memory() / (2 ** 30),
-                "ncores": core.get_num_threads(),
-            },
-        )
+            task_config=self.task_config,
+            )
         # ... END
 
         #pp.pprint(self.result.dict())

--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -193,6 +193,10 @@ def process_options_keywords(**kwargs) -> Dict:
         "VPT2_OMEGA_THRESH": 1,
         "QC_PROGRAM": "psi4",
         "MULTILEVEL": False,
+        "TASK_CONFIG": {
+            "memory": psi4.core.get_memory() / (2 ** 30),
+            "ncores": psi4.core.get_num_threads(),
+        }
     }
 
     for k in kwargs.keys():


### PR DESCRIPTION
## Description
Pass through `task_config` option for local qcengine tasks.

## Status
- [x] Ready to go
