### PR TITLE
Always use dummy basis in constructing wfn

### DIFF
--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -28,8 +28,7 @@ def _findif_schema_to_wfn(findif_model: AtomicResult) -> psi4.core.Wavefunction:
 
     # new skeleton wavefunction w/mol, highest-SCF basis (just to choose one), & not energy
     mol = psi4.core.Molecule.from_schema(findif_model.molecule.dict(), nonphysical=True)
-    sbasis = "def2-svp" if (findif_model.model.basis == "(auto)") else findif_model.model.basis
-    basis = psi4.core.BasisSet.build(mol, "ORBITAL", sbasis, quiet=True)
+    basis = psi4.core.BasisSet.build(mol, "ORBITAL", "def2-svp", quiet=True)
     wfn = psi4.core.Wavefunction(mol, basis)
     if hasattr(findif_model.provenance, "module"):
         wfn.set_module(findif_model.provenance.module)


### PR DESCRIPTION
## Description
Prevents issues when basis (or alias) used not in psi4. Basis object only used as dummy to construct wfn object to pass into psi4 vibrational analysis.


## Status
- [x] Ready to go
