### PR TITLE
Mend failing CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, "3.12"]
+        python-version: [3.9, "3.12"]
         psi4-version: [stable, nightly]
 
     steps:

--- a/devtools/conda-envs/test_env_nightly.yaml
+++ b/devtools/conda-envs/test_env_nightly.yaml
@@ -5,15 +5,15 @@ channels:
 
 dependencies:
   - psi4
-  - qcfractal
-  - qcportal < 0.56
+  - qcfractal >= 0.56
+  - qcportal >= 0.56
   - qcelemental
   - nwchem
 
     # Base depends
   - python
   - pip
-  - pydantic < 2
+  - pydantic
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env_nightly.yaml
+++ b/devtools/conda-envs/test_env_nightly.yaml
@@ -13,7 +13,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - pydantic
+  - pydantic < 2
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env_nightly.yaml
+++ b/devtools/conda-envs/test_env_nightly.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - psi4
   - qcfractal
-  - qcportal
+  - qcportal < 0.56
   - qcelemental
   - nwchem
 

--- a/devtools/conda-envs/test_env_stable.yaml
+++ b/devtools/conda-envs/test_env_stable.yaml
@@ -4,15 +4,15 @@ channels:
 
 dependencies:
   - psi4
-  - qcfractal
-  - qcportal < 0.56
+  - qcfractal >= 0.56
+  - qcportal >= 0.56
   - qcelemental
   - nwchem
 
     # Base depends
   - python
   - pip
-  - pydantic < 2
+  - pydantic
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env_stable.yaml
+++ b/devtools/conda-envs/test_env_stable.yaml
@@ -12,7 +12,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - pydantic
+  - pydantic < 2
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env_stable.yaml
+++ b/devtools/conda-envs/test_env_stable.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - psi4
   - qcfractal
-  - qcportal
+  - qcportal < 0.56
   - qcelemental
   - nwchem
 


### PR DESCRIPTION
## Description
- Prevent old `qcfractal` versions from being used in CI env
- Bump min python to 3.9

## Status
- [ ] Ready to go
