### PR TITLE
Fermi resonance checking for chi0

### DIFF
--- a/pyvpt2/vpt2.py
+++ b/pyvpt2/vpt2.py
@@ -487,7 +487,10 @@ def process_vpt2(quartic_result: AtomicResult, **kwargs) -> VPTResult:
                 chi[i, i] /= 16
 
             else:
-                chi0 += 3 * omega[i]* phi_ijk[i, j, j] ** 2 / (4 * omega[j] ** 2 - omega[i] ** 2)
+                if (i, (j,j)) in fermi_list:
+                    chi0 -= 3 * omega[j]* phi_ijk[i, j, j] ** 2 / (4 * omega[i] ** 2 + 2 * omega[i] * omega[j])
+                else: 
+                    chi0 += 3 * omega[i]* phi_ijk[i, j, j] ** 2 / (4 * omega[j] ** 2 - omega[i] ** 2)
                 chi[i, j] = phi_iijj[i, j]
                 rot = 0
                 for b_ind in range(0, 3):


### PR DESCRIPTION
## Description
The code in this pull request checks for fermi resonances in chi0 when computing terms that depend on phi_ijk[i, j, j]. If the code finds a resonance in fermi_list, it uses an alternate form for the denominator. This helps alleviate erratically-behaving total zpve, based on my testing.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go
